### PR TITLE
Prevent php warning error in logs

### DIFF
--- a/whois.php
+++ b/whois.php
@@ -358,7 +358,7 @@ class Whois{
 
 		$data = [];
 
-		while (!feof($f)){
+		while ($f !== false && !feof($f)){
 			$data[] = rtrim(fgets($f), "\n");
 		}
 		


### PR DESCRIPTION
flooding the php error logs with warnings:
 PHP Warning:  feof() expects parameter 1 to be resource, boolean given in /whois.php on line 361